### PR TITLE
Add template, label & input classes, and placeholder options

### DIFF
--- a/lib/client/modals.coffee
+++ b/lib/client/modals.coffee
@@ -31,7 +31,11 @@ Template.autoformModals.rendered = ->
 			'cmButtonContent',
 			'cmTitle',
 			'cmButtonClasses',
-			'cmPrompt'
+			'cmPrompt',
+			'cmTemplate',
+			'cmLabelClass',
+			'cmInputColClass',
+			'cmPlaceholder'
 		]
 		delete Session.keys[key] for key in sessionKeys
 
@@ -71,6 +75,14 @@ helpers =
 		Session.get 'cmButtonClasses'
 	cmPrompt: () ->
 		Session.get 'cmPrompt'
+	cmTemplate: () ->
+		Session.get 'cmTemplate'
+	cmLabelClass: () ->
+		Session.get 'cmLabelClass'
+	cmInputColClass: () ->
+		Session.get 'cmInputColClass'
+	cmPlaceholder: () ->
+		Session.get 'cmPlaceholder'
 	title: () ->
 		StringTemplate.compile '{{{cmTitle}}}', helpers
 	prompt: () ->
@@ -94,6 +106,10 @@ Template.afModal.events
 		Session.set 'cmOmitFields', t.data.omitFields
 		Session.set 'cmButtonHtml', html
 		Session.set 'cmTitle', t.data.title or html
+		Session.set 'cmTemplate', t.data.template
+		Session.set 'cmLabelClass', t.data.labelClass
+		Session.set 'cmInputColClass', t.data.inputColClass
+		Session.set 'cmPlaceholder', if t.data.placeholder is true then 'schemaLabel' else ''
 
 		if t.data.doc
 			Session.set 'cmDoc', collectionObj(t.data.collection).findOne _id: t.data.doc

--- a/lib/client/modals.html
+++ b/lib/client/modals.html
@@ -10,7 +10,7 @@
 					{{#if $and cmCollection cmOperation}}
 					<p>{{{prompt}}}</p>
 					{{#if $neq cmOperation 'remove'}}
-					{{> quickForm title=cmTitle id="cmForm" collection=cmCollection doc=cmDoc type=cmOperation buttonContent=cmButtonContent fields=cmFields omitFields=cmOmitFields buttonClasses=cmButtonClasses}}
+					{{> quickForm title=cmTitle id="cmForm" collection=cmCollection doc=cmDoc type=cmOperation buttonContent=cmButtonContent fields=cmFields omitFields=cmOmitFields template=cmTemplate label-class=cmLabelClass input-col-class=cmInputColClass buttonClasses=cmButtonClasses afFieldInput-placeholder=cmPlaceholder}}
 					{{/if}}
 					{{/if}}
 				</div>


### PR DESCRIPTION
PR to add some additional autoform options:

## Usage
In the #afModal you can add the following options:

### template
Can use any template string that autoform accepts. For example:
```
template='bootstrap3-horizontal'
```
### labelClass
Defines a bootstrap class for use when the horizontal class is used, how many columns should the label take? For example:
```
labelClass='col-sm-3'
```
### inputColClass
Defines a bootstrap class for use when the horizontal class is used, how many columns should the input take? For example:
```
inputColClass='col-sm-9'
```
### placeholder
Set to true if you wish to use the schema label for the input placeholder.
```
placeholder=true
```