### PR TITLE
changes to doc attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Collection should be the name of the global collection object e.g. Posts.
 
 Operation can be ```insert```,```update``` or ```remove```.
 
-If ```operation="update``` or ```operation="remove"``` you also need to set the ```doc``` property to the _id of the document.
+If ```operation="update"``` or ```operation="remove"``` you also need to set the ```doc``` property to the ```_id``` of the document or to an object containing the document. This object must contain the ```_id``` of the document. If ```operation="insert"``` you can optionally set the ```doc``` property to an object containing some data you want to insert into the document (but you can't use the ```_id``` instead of the object and the object shouldn't contain the ```_id`` either).
 
 ## Customisation ##
 It is possible to customise the modals by adding additional attributes to the `afModal` template.

--- a/lib/client/modals.coffee
+++ b/lib/client/modals.coffee
@@ -150,7 +150,10 @@ Template.afModal.events
 			registeredAutoFormHooks.push t.data.formId
 
 		if t.data.doc
-			Session.set 'cmDoc', collectionObj(t.data.collection).findOne _id: t.data.doc
+			if typeof t.data.doc is "string"
+				Session.set 'cmDoc', collectionObj(t.data.collection).findOne _id: t.data.doc
+			else
+				Session.set 'cmDoc', t.data.doc
 
 		if t.data.buttonContent
 			Session.set 'cmButtonContent', t.data.buttonContent


### PR DESCRIPTION
The doc attribute now also takes an object containing the document
instead of the _id. This is the standard behavior of autoform and also
allows to easily set up data for insert forms.