### PR TITLE
Added autoform type parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build*
+.idea

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ inputColClass='col-sm-9'
 * ```formId``` defines id of the `quickForm` template. Useful when you want to set your custom autoform hooks.
 * ```backdrop``` disables or enables modal-backdrop. Defaults to true (modal can be dismissed by mouse click). To disable use 'static' value. (See more [here](http://getbootstrap.com/javascript/#modals-options))
 * ```meteormethod``` if specified meteor method will be called on submit. This has the same effect as passing `type="method"` and `meteormethod` to autoform template. See autoform docs for more details.
+* ```type``` if specified the autoform type will be set accordingly. This overwrites anything set by ```meteormethod```. Useful for updating with a method.
 * ```onSuccess``` function to be called when operation succeeds. Currently it's supported for `operation="remove"` only.
 * ```dialogClass``` can be used to add additional class for `.modal-dialog` (e.g. `modal-sm`)
 

--- a/lib/client/modals.coffee
+++ b/lib/client/modals.coffee
@@ -45,6 +45,7 @@ Template.autoformModals.rendered = ->
 			'cmFormId',
 			'cmAutoformType',
 			'cmMeteorMethod',
+			'cmType',
 			'cmCloseButtonContent',
 			'cmCloseButtonClasses'
 		]
@@ -102,7 +103,9 @@ helpers =
 	cmFormId: () ->
 		Session.get('cmFormId') or defaultFormId
 	cmAutoformType: () ->
-		if Session.get 'cmMeteorMethod'
+		if Session.get('cmType')
+			Session.get('cmType')
+		else if Session.get 'cmMeteorMethod'
 			'method'
 		else
 			Session.get 'cmOperation'
@@ -141,6 +144,7 @@ Template.afModal.events
 		Session.set 'cmPlaceholder', if t.data.placeholder is true then 'schemaLabel' else ''
 		Session.set 'cmFormId', t.data.formId
 		Session.set 'cmMeteorMethod', t.data.meteormethod
+		Session.set 'cmType', t.data.type
 		Session.set 'cmModalDialogClass', t.data.dialogClass
 		Session.set 'cmModalContentClass', t.data.contentClass
 

--- a/lib/client/modals.coffee
+++ b/lib/client/modals.coffee
@@ -101,10 +101,10 @@ helpers =
 	cmPlaceholder: () ->
 		Session.get 'cmPlaceholder'
 	cmFormId: () ->
-		Session.get('cmFormId') or defaultFormId
+		Session.get 'cmFormId' or defaultFormId
 	cmAutoformType: () ->
-		if Session.get('cmType')
-			Session.get('cmType')
+		if Session.get 'cmType'
+			Session.get 'cmType'
 		else if Session.get 'cmMeteorMethod'
 			'method'
 		else


### PR DESCRIPTION
Hey,

the official Meteor guide recommends using methods for all operations on collections. This package did not support updating via method properly until now, as the autoform type was hardcoded to `method` without an option to adjust it. This tiny pull request adds an option for just that, which also fixes #66.

I tested this against my own local project. Would appreciate it if you'd accept this pull request so that I can start using the official package version again. 😄 
