### PR TITLE
Fix _.contains reference (Meteor 1.3 support)

### DIFF
--- a/lib/client/modals.coffee
+++ b/lib/client/modals.coffee
@@ -1,5 +1,3 @@
-_ = require 'underscore'
-
 registeredAutoFormHooks = ['cmForm']
 defaultFormId = 'cmForm'
 
@@ -10,9 +8,7 @@ AutoForm.addHooks 'cmForm',
 		$('#afModal').modal('hide')
 
 collectionObj = (name) ->
-	name.split('.').reduce (o, x) ->
-		o[x]
-	, window
+	Meteor.Collection.get(name)
 
 Template.autoformModals.rendered = ->
 	$('#afModal').modal(show: false)

--- a/lib/client/modals.coffee
+++ b/lib/client/modals.coffee
@@ -1,3 +1,5 @@
+_ = require 'underscore'
+
 registeredAutoFormHooks = ['cmForm']
 defaultFormId = 'cmForm'
 

--- a/package.js
+++ b/package.js
@@ -14,6 +14,7 @@ Package.on_use(function (api) {
     'less@2.5.0_2',
     'session',
     'coffeescript',
+    'underscore',
     'ui',
     'aldeed:autoform@5.5.1',
     'raix:handlebar-helpers@0.2.5',


### PR DESCRIPTION
Fixes https://github.com/yogiben/meteor-autoform-modals/issues/82

Note, I had to change my `collections=` argument on my template to use the lowercase version so `Meteor.Collection.get(name)` worked.
